### PR TITLE
PAE-279 - Pin the Reportlab package version.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
     install_requires=[
         'XBlock',
         'xblock-utils',
-        'reportlab',
+        'reportlab<3.5.54',
     ],
     entry_points={
         'xblock.v1': [


### PR DESCRIPTION
## Description:

This PR fixes the Reportlab package version. Version 3.5.54 drops support for Python 3.5.

## Reviewers:

- [ ] @luismorenolopera 
- [ ] @diegomillan 
- [ ] @morenol 